### PR TITLE
Title alignment fixed to center.

### DIFF
--- a/docs/css/index.css
+++ b/docs/css/index.css
@@ -5,7 +5,7 @@ body {
 }
 
 #title-text {
-    max-width: 100%;
+    width: max-content;
     margin-left: auto;
     margin-right: auto;
 }


### PR DESCRIPTION
h elements take 100% of width by default. So, to horizontally center align it, we have to limit their width to themselves (`width : max-content`).

Really cool project btw :)